### PR TITLE
Make raid commands ephemeral

### DIFF
--- a/Scruffy.Commands/SlashCommands/RaidAdminSlashCommandModule.cs
+++ b/Scruffy.Commands/SlashCommands/RaidAdminSlashCommandModule.cs
@@ -51,7 +51,7 @@ public class RaidAdminSlashCommandModule : SlashCommandModuleBase
     public async Task Leave([Summary("User")]IGuildUser user,
                             [Summary("Name", "Name of the appointment")]string name)
     {
-        var message = await Context.DeferProcessing()
+        var message = await Context.DeferProcessing(ephemeral: true)
                                    .ConfigureAwait(false);
 
         await CommandHandler.Leave(Context, user, name)
@@ -80,7 +80,7 @@ public class RaidAdminSlashCommandModule : SlashCommandModuleBase
                                   [Summary("Count", "Group count")]int count)
     {
         await Context.Interaction
-                     .DeferAsync()
+                     .DeferAsync(ephemeral: true)
                      .ConfigureAwait(false);
 
         await CommandHandler.SetTemplate(Context, name, count)

--- a/Scruffy.Commands/SlashCommands/RaidSlashCommandModule.cs
+++ b/Scruffy.Commands/SlashCommands/RaidSlashCommandModule.cs
@@ -43,7 +43,7 @@ public class RaidSlashCommandModule : SlashCommandModuleBase
     [SlashCommand("leave", "Leave an appointment")]
     public async Task Leave([Summary("Name", "Name of the appointment")]string name)
     {
-        var message = await Context.DeferProcessing()
+        var message = await Context.DeferProcessing(ephemeral: true)
                                    .ConfigureAwait(false);
 
         await CommandHandler.Leave(Context, name)
@@ -62,7 +62,7 @@ public class RaidSlashCommandModule : SlashCommandModuleBase
     public async Task Logs([Summary("day", "Day of the logs (yyyy-MM-dd)")]string day = null)
     {
         await Context.Interaction
-                     .DeferAsync()
+                     .DeferAsync(ephemeral: true)
                      .ConfigureAwait(false);
 
         await CommandHandler.Logs(Context, day)

--- a/Scruffy.Commands/TextCommands/GuildCommandModule.cs
+++ b/Scruffy.Commands/TextCommands/GuildCommandModule.cs
@@ -849,12 +849,12 @@ public class GuildCommandModule : LocatedTextCommandModuleBase
                                                   .ConfigureAwait(false);
                 if (embed != null)
                 {
-                    await Context.ReplyAsync(embed: embed)
+                    await Context.RespondAsync(embed: embed)
                                  .ConfigureAwait(false);
                 }
                 else
                 {
-                    await Context.ReplyAsync(LocalizationGroup.GetText("NoChangedRequired", "No rank changed are required."))
+                    await Context.RespondAsync(LocalizationGroup.GetText("NoChangedRequired", "No rank changed are required."))
                                  .ConfigureAwait(false);
                 }
             }

--- a/Scruffy.Services/Developer/DeveloperService.cs
+++ b/Scruffy.Services/Developer/DeveloperService.cs
@@ -74,7 +74,7 @@ public class DeveloperService : LocatedServiceBase
                                   .Refresh(obj => obj.Id == user.Id,
                                            obj => obj.GitHubAccount = accountName))
             {
-                await context.ReplyAsync(LocalizationGroup.GetText("AccountRefresh", "The account has been updated."))
+                await context.RespondAsync(LocalizationGroup.GetText("AccountRefresh", "The account has been updated."))
                              .ConfigureAwait(false);
             }
             else

--- a/Scruffy.Services/Discord/CommandContextContainer.cs
+++ b/Scruffy.Services/Discord/CommandContextContainer.cs
@@ -121,39 +121,16 @@ public sealed class CommandContextContainer : ICommandContext, ICommandContextOp
     /// <returns><see cref="MergedContextContainer"/>-Object</returns>
     public MergedContextContainer GetMergedContextContainer() => new(this);
 
-    /// <summary>
-    /// Reply to the user message or command
-    /// </summary>
-    /// <param name="text">The message to be sent.</param>
-    /// <param name="isTTS">Determines whether the message should be read aloud by Discord or not.</param>
-    /// <param name="embed">The <see cref="EmbedType.Rich"/> <see cref="Embed"/> to be sent.</param>
-    /// <param name="options">The options to be used when sending the request.</param>
-    /// <param name="allowedMentions">Specifies if notifications are sent for mentioned users and roles in the message <paramref name="text"/>. If <c>null</c>, all mentioned roles and users will be notified./// </param>
-    /// <param name="components">The message components to be included with this message. Used for interactions.</param>
-    /// <param name="stickers">A collection of stickers to send with the message.</param>
-    /// <param name="embeds">A array of <see cref="Embed"/>s to send with this response. Max 10.</param>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    public Task<IUserMessage> ReplyAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null, MessageComponent components = null, ISticker[] stickers = null, Embed[] embeds = null)
+    /// <inheritdoc/>
+    public Task<IUserMessage> RespondAsync(string text = null, Embed[] embeds = null, bool isTTS = false, bool ephemeral = false, AllowedMentions allowedMentions = null, MessageComponent components = null, Embed embed = null, RequestOptions options = null)
     {
-        return Message.ReplyAsync(text, isTTS, embed, allowedMentions, options, components, stickers, embeds);
+        return Message.ReplyAsync(text: text, embeds: embeds, isTTS: isTTS, allowedMentions: allowedMentions, components: components, embed: embed, options: options);
     }
 
-    /// <summary>
-    /// Reply to the user message or command
-    /// </summary>
-    /// <param name="text">The message to be sent.</param>
-    /// <param name="isTTS">Determines whether the message should be read aloud by Discord or not.</param>
-    /// <param name="embed">The <see cref="EmbedType.Rich"/> <see cref="Embed"/> to be sent.</param>
-    /// <param name="options">The options to be used when sending the request.</param>
-    /// <param name="allowedMentions">Specifies if notifications are sent for mentioned users and roles in the message <paramref name="text"/>. If <c>null</c>, all mentioned roles and users will be notified./// </param>
-    /// <param name="messageReference">The message references to be included. Used to reply to specific messages.</param>
-    /// <param name="components">The message components to be included with this message. Used for interactions.</param>
-    /// <param name="stickers">A collection of stickers to send with the message.</param>
-    /// <param name="embeds">A array of <see cref="Embed"/>s to send with this response. Max 10.</param>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    public Task<IUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null, MessageReference messageReference = null, MessageComponent components = null, ISticker[] stickers = null, Embed[] embeds = null)
+    /// <inheritdoc/>
+    public Task<IUserMessage> SendMessageAsync(string text = null, Embed[] embeds = null, bool isTTS = false, bool ephemeral = false, AllowedMentions allowedMentions = null, MessageComponent components = null, Embed embed = null, RequestOptions options = null)
     {
-        return Channel.SendMessageAsync(text, isTTS, embed, options, allowedMentions, messageReference, components, stickers, embeds);
+        return Channel.SendMessageAsync(text: text, embeds: embeds, isTTS: isTTS, allowedMentions: allowedMentions, components: components, embed: embed, options: options);
     }
 
     /// <summary>

--- a/Scruffy.Services/Discord/CommandHelpService.cs
+++ b/Scruffy.Services/Discord/CommandHelpService.cs
@@ -275,7 +275,7 @@ public class CommandHelpService : LocatedServiceBase
             }
         }
 
-        await context.ReplyAsync(embed: embedBuilder.Build())
+        await context.RespondAsync(embed: embedBuilder.Build())
                      .ConfigureAwait(false);
     }
 

--- a/Scruffy.Services/Discord/DialogButtonElementBase.cs
+++ b/Scruffy.Services/Discord/DialogButtonElementBase.cs
@@ -67,7 +67,7 @@ public abstract class DialogButtonElementBase<TData> : DialogElementBase<TData>
                 }
             }
 
-            var message = await CommandContext.SendMessageAsync(GetMessage(), components: componentsBuilder.Build())
+            var message = await CommandContext.SendMessageAsync(GetMessage(), ephemeral: IsEphemeral(), components: componentsBuilder.Build())
                                               .ConfigureAwait(false);
 
             DialogContext.Messages.Add(message);

--- a/Scruffy.Services/Discord/DialogElementBase.cs
+++ b/Scruffy.Services/Discord/DialogElementBase.cs
@@ -69,6 +69,12 @@ public abstract class DialogElementBase
     /// <returns>Result</returns>
     internal abstract Task<object> InternalRun();
 
+    /// <summary>
+    /// Whether the return message is ephemeral
+    /// </summary>
+    /// <returns>Ephemeral</returns>
+    public virtual bool IsEphemeral() => false;
+
     #endregion // Methods
 }
 

--- a/Scruffy.Services/Discord/DialogSelectMenuElementBase.cs
+++ b/Scruffy.Services/Discord/DialogSelectMenuElementBase.cs
@@ -77,7 +77,7 @@ public abstract class DialogSelectMenuElementBase<TData> : DialogElementBase<TDa
                 componentsBuilder.WithSelectMenu(selectMenu);
             }
 
-            var message = await CommandContext.SendMessageAsync(GetMessage(), components: componentsBuilder.Build())
+            var message = await CommandContext.SendMessageAsync(GetMessage(), ephemeral: IsEphemeral(), components: componentsBuilder.Build())
                                               .ConfigureAwait(false);
 
             DialogContext.Messages.Add(message);

--- a/Scruffy.Services/Discord/Interfaces/IContextContainer.cs
+++ b/Scruffy.Services/Discord/Interfaces/IContextContainer.cs
@@ -59,30 +59,29 @@ public interface IContextContainer
     /// Reply to the user message or command
     /// </summary>
     /// <param name="text">The message to be sent.</param>
+    /// <param name="embeds">A array of <see cref="Embed"/>s to send with this response. Max 10.</param>
     /// <param name="isTTS">Determines whether the message should be read aloud by Discord or not.</param>
-    /// <param name="embed">The <see cref="EmbedType.Rich"/> <see cref="Embed"/> to be sent.</param>
-    /// <param name="options">The options to be used when sending the request.</param>
+    /// <param name="ephemeral">Whether all user can see the message or only the sender.</param>
     /// <param name="allowedMentions">Specifies if notifications are sent for mentioned users and roles in the message <paramref name="text"/>. If <c>null</c>, all mentioned roles and users will be notified./// </param>
     /// <param name="components">The message components to be included with this message. Used for interactions.</param>
-    /// <param name="stickers">A collection of stickers to send with the message.</param>
-    /// <param name="embeds">A array of <see cref="Embed"/>s to send with this response. Max 10.</param>
+    /// <param name="embed">The <see cref="EmbedType.Rich"/> <see cref="Embed"/> to be sent.</param>
+    /// <param name="options">The options to be used when sending the request.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    Task<IUserMessage> ReplyAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null, MessageComponent components = null, ISticker[] stickers = null, Embed[] embeds = null);
+    Task<IUserMessage> RespondAsync(string text = null, Embed[] embeds = null, bool isTTS = false, bool ephemeral = false, AllowedMentions allowedMentions = null, MessageComponent components = null, Embed embed = null, RequestOptions options = null);
 
     /// <summary>
     /// Reply to the user message or command
     /// </summary>
     /// <param name="text">The message to be sent.</param>
+    /// <param name="embeds">A array of <see cref="Embed"/>s to send with this response. Max 10.</param>
     /// <param name="isTTS">Determines whether the message should be read aloud by Discord or not.</param>
+    /// <param name="ephemeral">Whether all user can see the message or only the sender.</param>
+    /// <param name="allowedMentions">Specifies if notifications are sent for mentioned users and roles in the message <paramref name="text"/>. If <c>null</c>, all mentioned roles and users will be notified./// </param>
+    /// <param name="components">The message components to be included with this message. Used for interactions.</param>
     /// <param name="embed">The <see cref="EmbedType.Rich"/> <see cref="Embed"/> to be sent.</param>
     /// <param name="options">The options to be used when sending the request.</param>
-    /// <param name="allowedMentions">Specifies if notifications are sent for mentioned users and roles in the message <paramref name="text"/>. If <c>null</c>, all mentioned roles and users will be notified./// </param>
-    /// <param name="messageReference">The message references to be included. Used to reply to specific messages.</param>
-    /// <param name="components">The message components to be included with this message. Used for interactions.</param>
-    /// <param name="stickers">A collection of stickers to send with the message.</param>
-    /// <param name="embeds">A array of <see cref="Embed"/>s to send with this response. Max 10.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    Task<IUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null, MessageReference messageReference = null, MessageComponent components = null, ISticker[] stickers = null, Embed[] embeds = null);
+    Task<IUserMessage> SendMessageAsync(string text = null, Embed[] embeds = null, bool isTTS = false, bool ephemeral = false, AllowedMentions allowedMentions = null, MessageComponent components = null, Embed embed = null, RequestOptions options = null);
 
     #endregion // Methods
 }

--- a/Scruffy.Services/Discord/MergedContextContainer.cs
+++ b/Scruffy.Services/Discord/MergedContextContainer.cs
@@ -116,39 +116,16 @@ public sealed class MergedContextContainer : IInteractionContext, ICommandContex
     /// <returns><see cref="MergedContextContainer"/>-Object</returns>
     public MergedContextContainer GetMergedContextContainer() => this;
 
-    /// <summary>
-    /// Reply to the user message or command
-    /// </summary>
-    /// <param name="text">The message to be sent.</param>
-    /// <param name="isTTS">Determines whether the message should be read aloud by Discord or not.</param>
-    /// <param name="embed">The <see cref="EmbedType.Rich"/> <see cref="Embed"/> to be sent.</param>
-    /// <param name="options">The options to be used when sending the request.</param>
-    /// <param name="allowedMentions">Specifies if notifications are sent for mentioned users and roles in the message <paramref name="text"/>. If <c>null</c>, all mentioned roles and users will be notified./// </param>
-    /// <param name="components">The message components to be included with this message. Used for interactions.</param>
-    /// <param name="stickers">A collection of stickers to send with the message.</param>
-    /// <param name="embeds">A array of <see cref="Embed"/>s to send with this response. Max 10.</param>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    public Task<IUserMessage> ReplyAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null, MessageComponent components = null, ISticker[] stickers = null, Embed[] embeds = null)
+    /// <inheritdoc/>
+    public Task<IUserMessage> RespondAsync(string text = null, Embed[] embeds = null, bool isTTS = false, bool ephemeral = false, AllowedMentions allowedMentions = null, MessageComponent components = null, Embed embed = null, RequestOptions options = null)
     {
-        return _container.ReplyAsync(text, isTTS, embed, options, allowedMentions, components, stickers, embeds);
+        return _container.RespondAsync(text, embeds, isTTS, ephemeral, allowedMentions, components, embed, options);
     }
 
-    /// <summary>
-    /// Reply to the user message or command
-    /// </summary>
-    /// <param name="text">The message to be sent.</param>
-    /// <param name="isTTS">Determines whether the message should be read aloud by Discord or not.</param>
-    /// <param name="embed">The <see cref="EmbedType.Rich"/> <see cref="Embed"/> to be sent.</param>
-    /// <param name="options">The options to be used when sending the request.</param>
-    /// <param name="allowedMentions">Specifies if notifications are sent for mentioned users and roles in the message <paramref name="text"/>. If <c>null</c>, all mentioned roles and users will be notified./// </param>
-    /// <param name="messageReference">The message references to be included. Used to reply to specific messages.</param>
-    /// <param name="components">The message components to be included with this message. Used for interactions.</param>
-    /// <param name="stickers">A collection of stickers to send with the message.</param>
-    /// <param name="embeds">A array of <see cref="Embed"/>s to send with this response. Max 10.</param>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    public Task<IUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null, MessageReference messageReference = null, MessageComponent components = null, ISticker[] stickers = null, Embed[] embeds = null)
+    /// <inheritdoc/>
+    public Task<IUserMessage> SendMessageAsync(string text = null, Embed[] embeds = null, bool isTTS = false, bool ephemeral = false, AllowedMentions allowedMentions = null, MessageComponent components = null, Embed embed = null, RequestOptions options = null)
     {
-        return _container.SendMessageAsync(text, isTTS, embed, options, allowedMentions, messageReference, components, stickers, embeds);
+        return _container.SendMessageAsync(text, embeds, isTTS, ephemeral, allowedMentions, components, embed, options);
     }
 
     #endregion // IContextContainer

--- a/Scruffy.Services/GuildWars2/ItemsService.cs
+++ b/Scruffy.Services/GuildWars2/ItemsService.cs
@@ -119,7 +119,7 @@ public class ItemsService : LocatedServiceBase
             }
             else
             {
-                await context.ReplyAsync(LocalizationGroup.GetText("InvalidItem", "There is no item with the specified ID."))
+                await context.RespondAsync(LocalizationGroup.GetText("InvalidItem", "There is no item with the specified ID."))
                              .ConfigureAwait(false);
             }
         }

--- a/Scruffy.Services/Raid/DialogElements/RaidRoleSelectionDialogElement.cs
+++ b/Scruffy.Services/Raid/DialogElements/RaidRoleSelectionDialogElement.cs
@@ -41,26 +41,20 @@ public class RaidRoleSelectionDialogElement : DialogSelectMenuElementBase<long?>
 
     #region DialogEmbedMessageElementBase<long?>
 
-    /// <summary>
-    /// Returning the message
-    /// </summary>
-    /// <returns>Message</returns>
-    public override string GetMessage() => CommandContext.User.Mention + " " + (_mainRoleId == null
+    /// <inheritdoc/>
+    public override string GetMessage() => _mainRoleId == null
                                                ? LocalizationGroup.GetText("ChooseMainRoleTitle", "Role selection")
-                                               : LocalizationGroup.GetText("ChooseSubRoleTitle", "Class selection"));
+                                               : LocalizationGroup.GetText("ChooseSubRoleTitle", "Class selection");
 
-    /// <summary>
-    /// Returning the placeholder
-    /// </summary>
-    /// <returns>Placeholder</returns>
+    /// <inheritdoc/>
+    public override bool IsEphemeral() => true;
+
+    /// <inheritdoc/>
     public override string GetPlaceholder() => _mainRoleId == null
                                                    ? LocalizationGroup.GetText("ChooseMainRoleDescription", "Please choose one of the following roles...")
                                                    : LocalizationGroup.GetText("ChooseSubRoleDescription", "Please choose one of the following classes...");
 
-    /// <summary>
-    /// Returns the select menu entries which should be added to the message
-    /// </summary>
-    /// <returns>Reactions</returns>
+    /// <inheritdoc/>
     public override IReadOnlyList<SelectMenuEntryData<long?>> GetEntries()
     {
         if (_entries == null)
@@ -104,10 +98,7 @@ public class RaidRoleSelectionDialogElement : DialogSelectMenuElementBase<long?>
         return _entries;
     }
 
-    /// <summary>
-    /// Default case if none of the given buttons is used
-    /// </summary>
-    /// <returns>Result</returns>
+    /// <inheritdoc/>
     protected override long? DefaultFunc() => throw new InvalidOperationException();
 
     #endregion // DialogEmbedMessageElementBase<long?>

--- a/Scruffy.Services/Raid/DialogElements/RaidRoleSelectionNextDialogElement.cs
+++ b/Scruffy.Services/Raid/DialogElements/RaidRoleSelectionNextDialogElement.cs
@@ -39,17 +39,14 @@ public class RaidRoleSelectionNextDialogElement : DialogButtonElementBase<bool>
 
     #region DialogReactionElementBase<bool>
 
-    /// <summary>
-    /// Editing the embedded message
-    /// </summary>
-    /// <returns>Message</returns>
+    /// <inheritdoc/>
     public override string GetMessage() => _first ? LocalizationGroup.GetText("MessageFirst", "Do you want to add role preference?")
                                                : LocalizationGroup.GetText("MessageNext", "Do you want to add another role preference?");
 
-    /// <summary>
-    /// Returns the buttons which should be added to the message
-    /// </summary>
-    /// <returns>Reactions</returns>
+    /// <inheritdoc/>
+    public override bool IsEphemeral() => true;
+
+    /// <inheritdoc/>
     public override IReadOnlyList<ButtonData<bool>> GetButtons()
     {
         return _buttons ??= new List<ButtonData<bool>>
@@ -69,10 +66,7 @@ public class RaidRoleSelectionNextDialogElement : DialogButtonElementBase<bool>
                             };
     }
 
-    /// <summary>
-    /// Default case if none of the given reactions is used
-    /// </summary>
-    /// <returns>Result</returns>
+    /// <inheritdoc/>
     protected override bool DefaultFunc() => false;
 
     #endregion // DialogReactionElementBase

--- a/Scruffy.Services/Raid/RaidCommandHandler.cs
+++ b/Scruffy.Services/Raid/RaidCommandHandler.cs
@@ -190,7 +190,7 @@ public class RaidCommandHandler : LocatedServiceBase
             }
             else
             {
-                await container.ReplyAsync(LocalizationGroup.GetText("NoActiveAppointment", "Currently there is no active appointment."))
+                await container.RespondAsync(LocalizationGroup.GetText("NoActiveAppointment", "Currently there is no active appointment."))
                                .ConfigureAwait(false);
             }
         }
@@ -235,7 +235,7 @@ public class RaidCommandHandler : LocatedServiceBase
             }
             else
             {
-                await container.ReplyAsync(LocalizationGroup.GetText("NoActiveAppointment", "Currently there is no active appointment."))
+                await container.RespondAsync(LocalizationGroup.GetText("NoActiveAppointment", "Currently there is no active appointment."))
                                .ConfigureAwait(false);
             }
         }
@@ -284,7 +284,7 @@ public class RaidCommandHandler : LocatedServiceBase
             }
             else
             {
-                await container.ReplyAsync(LocalizationGroup.GetText("NoActiveAppointment", "Currently there is no active appointment."))
+                await container.RespondAsync(LocalizationGroup.GetText("NoActiveAppointment", "Currently there is no active appointment."))
                                .ConfigureAwait(false);
             }
         }
@@ -334,7 +334,7 @@ public class RaidCommandHandler : LocatedServiceBase
             }
             else
             {
-                await container.ReplyAsync(LocalizationGroup.GetText("NoActiveAppointment", "Currently there is no active appointment."))
+                await container.RespondAsync(LocalizationGroup.GetText("NoActiveAppointment", "Currently there is no active appointment."))
                                .ConfigureAwait(false);
             }
         }
@@ -376,7 +376,7 @@ public class RaidCommandHandler : LocatedServiceBase
             }
             else
             {
-                await container.ReplyAsync(LocalizationGroup.GetText("NoActiveAppointment", "Currently there is no active appointment."))
+                await container.RespondAsync(LocalizationGroup.GetText("NoActiveAppointment", "Currently there is no active appointment."))
                                .ConfigureAwait(false);
             }
         }
@@ -413,13 +413,13 @@ public class RaidCommandHandler : LocatedServiceBase
                     await _messageBuilder.RefreshMessageAsync(appointment.ConfigurationId)
                                         .ConfigureAwait(false);
 
-                    await container.ReplyAsync(LocalizationGroup.GetText("GroupCountChanged", "The group count has been changed."))
+                    await container.RespondAsync(LocalizationGroup.GetText("GroupCountChanged", "The group count has been changed."))
                                    .ConfigureAwait(false);
                 }
             }
             else
             {
-                await container.ReplyAsync(LocalizationGroup.GetText("NoActiveAppointment", "Currently there is no active appointment."))
+                await container.RespondAsync(LocalizationGroup.GetText("NoActiveAppointment", "Currently there is no active appointment."))
                                .ConfigureAwait(false);
             }
         }
@@ -532,7 +532,7 @@ public class RaidCommandHandler : LocatedServiceBase
 
                 if (isFirstMessage)
                 {
-                    await context.ReplyAsync(embed: embedBuilder.Build())
+                    await context.RespondAsync(embed: embedBuilder.Build())
                                  .ConfigureAwait(false);
 
                     isFirstMessage = false;
@@ -546,7 +546,7 @@ public class RaidCommandHandler : LocatedServiceBase
         }
         else
         {
-            await context.ReplyAsync(LocalizationGroup.GetText("NoDpsReportToken", "The are no DPS-Report user tokens assigned to your account."))
+            await context.RespondAsync(LocalizationGroup.GetText("NoDpsReportToken", "The are no DPS-Report user tokens assigned to your account."))
                          .ConfigureAwait(false);
         }
     }
@@ -624,7 +624,7 @@ public class RaidCommandHandler : LocatedServiceBase
         stringBuilder.AppendLine($"{Format.Url("Snow Crows", "https://snowcrows.com/")} - {Format.Url("Lucky Noobs", "https://lucky-noobs.com/")} - {Format.Url("Hardstuck", "https://hardstuck.gg/")}");
         builder.AddField("Builds", stringBuilder.ToString());
 
-        await container.ReplyAsync(embed: builder.Build())
+        await container.RespondAsync(embed: builder.Build())
                        .ConfigureAwait(false);
     }
 

--- a/Scruffy.Services/Raid/RaidCommandHandler.cs
+++ b/Scruffy.Services/Raid/RaidCommandHandler.cs
@@ -190,7 +190,7 @@ public class RaidCommandHandler : LocatedServiceBase
             }
             else
             {
-                await container.RespondAsync(LocalizationGroup.GetText("NoActiveAppointment", "Currently there is no active appointment."))
+                await container.RespondAsync(LocalizationGroup.GetText("NoActiveAppointment", "Currently there is no active appointment."), ephemeral: true)
                                .ConfigureAwait(false);
             }
         }
@@ -235,7 +235,7 @@ public class RaidCommandHandler : LocatedServiceBase
             }
             else
             {
-                await container.RespondAsync(LocalizationGroup.GetText("NoActiveAppointment", "Currently there is no active appointment."))
+                await container.RespondAsync(LocalizationGroup.GetText("NoActiveAppointment", "Currently there is no active appointment."), ephemeral: true)
                                .ConfigureAwait(false);
             }
         }
@@ -284,7 +284,7 @@ public class RaidCommandHandler : LocatedServiceBase
             }
             else
             {
-                await container.RespondAsync(LocalizationGroup.GetText("NoActiveAppointment", "Currently there is no active appointment."))
+                await container.RespondAsync(LocalizationGroup.GetText("NoActiveAppointment", "Currently there is no active appointment."), ephemeral: true)
                                .ConfigureAwait(false);
             }
         }
@@ -334,7 +334,7 @@ public class RaidCommandHandler : LocatedServiceBase
             }
             else
             {
-                await container.RespondAsync(LocalizationGroup.GetText("NoActiveAppointment", "Currently there is no active appointment."))
+                await container.RespondAsync(LocalizationGroup.GetText("NoActiveAppointment", "Currently there is no active appointment."), ephemeral: true)
                                .ConfigureAwait(false);
             }
         }
@@ -370,13 +370,13 @@ public class RaidCommandHandler : LocatedServiceBase
                     await _messageBuilder.RefreshMessageAsync(appointment.ConfigurationId)
                                          .ConfigureAwait(false);
 
-                    await container.SendMessageAsync(LocalizationGroup.GetText("TemplateChanged", "The template has been changed."))
+                    await container.RespondAsync(LocalizationGroup.GetText("TemplateChanged", "The template has been changed."), ephemeral: true)
                                    .ConfigureAwait(false);
                 }
             }
             else
             {
-                await container.RespondAsync(LocalizationGroup.GetText("NoActiveAppointment", "Currently there is no active appointment."))
+                await container.RespondAsync(LocalizationGroup.GetText("NoActiveAppointment", "Currently there is no active appointment."), ephemeral: true)
                                .ConfigureAwait(false);
             }
         }
@@ -413,13 +413,13 @@ public class RaidCommandHandler : LocatedServiceBase
                     await _messageBuilder.RefreshMessageAsync(appointment.ConfigurationId)
                                         .ConfigureAwait(false);
 
-                    await container.RespondAsync(LocalizationGroup.GetText("GroupCountChanged", "The group count has been changed."))
+                    await container.RespondAsync(LocalizationGroup.GetText("GroupCountChanged", "The group count has been changed."), ephemeral: true)
                                    .ConfigureAwait(false);
                 }
             }
             else
             {
-                await container.RespondAsync(LocalizationGroup.GetText("NoActiveAppointment", "Currently there is no active appointment."))
+                await container.RespondAsync(LocalizationGroup.GetText("NoActiveAppointment", "Currently there is no active appointment."), ephemeral: true)
                                .ConfigureAwait(false);
             }
         }
@@ -546,7 +546,7 @@ public class RaidCommandHandler : LocatedServiceBase
         }
         else
         {
-            await context.RespondAsync(LocalizationGroup.GetText("NoDpsReportToken", "The are no DPS-Report user tokens assigned to your account."))
+            await context.RespondAsync(LocalizationGroup.GetText("NoDpsReportToken", "The are no DPS-Report user tokens assigned to your account."), ephemeral: true)
                          .ConfigureAwait(false);
         }
     }

--- a/Scruffy.Services/Raid/RaidCommitService.cs
+++ b/Scruffy.Services/Raid/RaidCommitService.cs
@@ -177,7 +177,7 @@ public class RaidCommitService : LocatedServiceBase
             }
             else
             {
-                await commandContext.ReplyAsync(LocalizationGroup.GetText("NoOpenAppointment", "There is no uncommitted appointment available."))
+                await commandContext.RespondAsync(LocalizationGroup.GetText("NoOpenAppointment", "There is no uncommitted appointment available."))
                                     .ConfigureAwait(false);
             }
         }

--- a/Scruffy.Services/Raid/RaidCommitService.cs
+++ b/Scruffy.Services/Raid/RaidCommitService.cs
@@ -142,8 +142,7 @@ public class RaidCommitService : LocatedServiceBase
                     {
                     }
 
-                    await commandContext.Channel
-                                        .SendMessageAsync(LocalizationGroup.GetText("CommitCompleted", "The raid appointment has been committed."))
+                    await commandContext.RespondAsync(LocalizationGroup.GetText("CommitCompleted", "The raid appointment has been committed."), ephemeral: true)
                                         .ConfigureAwait(false);
 
                     await _messageBuilder.RefreshMessageAsync(appointment.ConfigurationId)
@@ -177,7 +176,7 @@ public class RaidCommitService : LocatedServiceBase
             }
             else
             {
-                await commandContext.RespondAsync(LocalizationGroup.GetText("NoOpenAppointment", "There is no uncommitted appointment available."))
+                await commandContext.RespondAsync(LocalizationGroup.GetText("NoOpenAppointment", "There is no uncommitted appointment available."), ephemeral: true)
                                     .ConfigureAwait(false);
             }
         }

--- a/Scruffy.Services/Raid/RaidRegistrationService.cs
+++ b/Scruffy.Services/Raid/RaidRegistrationService.cs
@@ -130,7 +130,7 @@ public class RaidRegistrationService : LocatedServiceBase
             }
             else
             {
-                await commandContext.ReplyAsync(LocalizationGroup.GetText("RequiredExperienceLevelMissing", "You don't have the required experience level."))
+                await commandContext.RespondAsync(LocalizationGroup.GetText("RequiredExperienceLevelMissing", "You don't have the required experience level."))
                                     .ConfigureAwait(false);
             }
         }

--- a/Scruffy.Services/Raid/RaidRegistrationService.cs
+++ b/Scruffy.Services/Raid/RaidRegistrationService.cs
@@ -130,7 +130,7 @@ public class RaidRegistrationService : LocatedServiceBase
             }
             else
             {
-                await commandContext.RespondAsync(LocalizationGroup.GetText("RequiredExperienceLevelMissing", "You don't have the required experience level."))
+                await commandContext.RespondAsync(LocalizationGroup.GetText("RequiredExperienceLevelMissing", "You don't have the required experience level."), ephemeral: true)
                                     .ConfigureAwait(false);
             }
         }


### PR DESCRIPTION
This allows much cleaner raid command handling, as only the requesting user sees the response messages from Scruffy.